### PR TITLE
Fixed temporary headshot offsets from being applied more than once

### DIFF
--- a/Assets/Scripts/ObjectScripts/UIScripts/GenerateHeadshot.cs
+++ b/Assets/Scripts/ObjectScripts/UIScripts/GenerateHeadshot.cs
@@ -23,6 +23,10 @@ public class GenerateHeadshot : MonoBehaviour
     private SpriteLibrary m_spriteLibrary;
     private bool m_initializedSusscessfully;
 
+    private static readonly string HAT = "hat";
+    private static readonly string HEAD = "Head";
+    private static readonly string BODY = "Body";
+
     private void Awake()
     {
         // Cache sprite library
@@ -34,7 +38,7 @@ public class GenerateHeadshot : MonoBehaviour
         // Make sure prefab is set up correctly
         if (m_hat == null || m_head == null || m_body == null)
         {
-            Debug.LogError("GenerateHeadshot.Awake : At least one of the headshot GameObjects are null!");
+            Debug.LogWarning("GenerateHeadshot.Awake : At least one of the headshot GameObjects are null!");
         }
         else
         {
@@ -44,7 +48,7 @@ public class GenerateHeadshot : MonoBehaviour
 
             if (m_hatImage == null || m_headImage == null || m_bodyImage == null)
             {
-                Debug.LogError("GenerateHeadshot.Awake : At least one of the headshot UI.Image objects are null!");
+                Debug.LogWarning("GenerateHeadshot.Awake : At least one of the headshot UI.Image objects are null!");
             }
             else
             {
@@ -52,7 +56,7 @@ public class GenerateHeadshot : MonoBehaviour
             }
         }
 
-        PerformCleanup(); // HACK
+        PerformCleanup(); // HACK       
     }
 
     /// <summary>
@@ -67,15 +71,14 @@ public class GenerateHeadshot : MonoBehaviour
     {
         if (m_initializedSusscessfully == false)
         {
-            Debug.LogError("GenerateHeadshot.CreateHeadshot : bad initialization!");
             return;
         }
 
         string labelToString = label.ToString();
 
-        SetImage(m_hatImage, "hat", labelToString);
-        SetImage(m_headImage, "Head", labelToString);
-        SetImage(m_bodyImage, "Body", labelToString);
+        SetImage(m_hatImage, HAT, labelToString);
+        SetImage(m_headImage, HEAD, labelToString);
+        SetImage(m_bodyImage, BODY, labelToString);
     }
 
     /// <summary>

--- a/Assets/Scripts/ObjectScripts/UIScripts/GenerateHeadshot.cs
+++ b/Assets/Scripts/ObjectScripts/UIScripts/GenerateHeadshot.cs
@@ -51,6 +51,8 @@ public class GenerateHeadshot : MonoBehaviour
                 m_initializedSusscessfully = true;
             }
         }
+
+        PerformCleanup(); // HACK
     }
 
     /// <summary>
@@ -74,8 +76,6 @@ public class GenerateHeadshot : MonoBehaviour
         SetImage(m_hatImage, "hat", labelToString);
         SetImage(m_headImage, "Head", labelToString);
         SetImage(m_bodyImage, "Body", labelToString);
-
-        PerformCleanup(); // HACK
     }
 
     /// <summary>


### PR DESCRIPTION
This is a fix for what should be a very temporary way of aligning sprites in the headshot generation functionality. The offsets were being applied more than once, causing the head to be further separated from the body and hat each time the menu was opened.