### PR TITLE
Render settings moved to helper class

### DIFF
--- a/Assets/Scripts/Managers/TimeManager.cs
+++ b/Assets/Scripts/Managers/TimeManager.cs
@@ -83,8 +83,6 @@ public class TimeManager : MonoBehaviour
 	//time of day tracker
 	public TimeOfDayTracker dayTrack;
 
-    private float m_hootelTimeScale = 1.0f;
-
     /// <summary>
     /// Real world time that in-game hours take in seconds
     /// </summary>
@@ -176,6 +174,12 @@ public class TimeManager : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Return the time remaining between the current phase and the
+    /// DayPhase provided in minutes.
+    /// </summary>
+    /// <param name="dayPhase">DayPhase to get remaining time until.</param>
+    /// <returns>Remaining time in minutes.</returns>
     public float TimeRemainingUntil(DayPhase dayPhase)
     {
         float timeRemaining = 0.0f;
@@ -202,6 +206,10 @@ public class TimeManager : MonoBehaviour
         return timeRemaining;
     }
 
+    /// <summary>
+    /// Length of current DayPhase in minutes.
+    /// </summary>
+    /// <returns>Length of current DayPhase in minutes.</returns>
     public float LengthOfCurrentPhase()
     {
         float phaseLength = 0.0f;
@@ -223,22 +231,6 @@ public class TimeManager : MonoBehaviour
         }
 
         return phaseLength;
-    }
-
-    public float GetQuarterDayLength()
-    {
-        return quarterDay;
-    }
-
-    public float GetHootelTimeScale()
-    {
-        return m_hootelTimeScale;
-    }
-
-    public void SetHootelTimeScale(float timeScale)
-    {
-        // TODO : CLAMP THE TIMESCALE
-        m_hootelTimeScale = timeScale;
     }
 
     /// Sets the script control fields to reasonable default values for an acceptable day/night cycle effect.  
@@ -293,19 +285,19 @@ public class TimeManager : MonoBehaviour
         // Rudementary phase-check algorithm:  
         if (currentCycleTime > nightTime && currentPhase == DayPhase.Dusk)
         {
-            SetNight();
+            currentPhase = DayPhase.Night;
         }
         else if (currentCycleTime > duskTime && currentPhase == DayPhase.Day)
         {
-            SetDusk();
+            currentPhase = DayPhase.Dusk;
         }
         else if (currentCycleTime > dayTime && currentPhase == DayPhase.Dawn)
         {
-            SetDay();
+            currentPhase = DayPhase.Day;
         }
         else if (currentCycleTime > dawnTime && currentCycleTime < dayTime && currentPhase == DayPhase.Night)
         {
-            SetDawn();
+            currentPhase = DayPhase.Dawn;
         }
 
         // Perform standard updates:  
@@ -316,7 +308,7 @@ public class TimeManager : MonoBehaviour
             currentCycleTime = currentCycleTime % dayCycleLength;
         else if (currentCycleTime == dayCycleLength)
             currentCycleTime = 0;
-        currentCycleTime += Time.deltaTime * m_hootelTimeScale;
+        currentCycleTime += Time.deltaTime;
         if (currentCycleTime > dayCycleLength)
             currentCycleTime = dayCycleLength;
 
@@ -335,35 +327,6 @@ public class TimeManager : MonoBehaviour
 
     #endregion
 
-    #region Day State Change Functions
-    /// Sets the currentPhase to Dawn, turning on the directional light, if any.  
-    public void SetDawn()
-    {
-        currentPhase = DayPhase.Dawn;
-    }
-
-    /// Sets the currentPhase to Day, ensuring full day color ambient light, and full  
-    /// directional light intensity, if any.  
-    public void SetDay()
-    {
-        currentPhase = DayPhase.Day;
-    }
-
-    /// Sets the currentPhase to Dusk.  
-    public void SetDusk()
-    {
-        currentPhase = DayPhase.Dusk;
-    }
-
-    /// Sets the currentPhase to Night, ensuring full night color ambient light, and  
-    /// turning off the directional light, if any.  
-    public void SetNight()
-    {
-        currentPhase = DayPhase.Night;
-    }
-
-    #endregion
-
     #region Update Helper Functions
     /// Updates the World-time hour based on the current time of day.  
     private void UpdateWorldTime()
@@ -377,7 +340,6 @@ public class TimeManager : MonoBehaviour
     }
     #endregion
 
-    
     public enum DayPhase
     {
         Night = 0,

--- a/Assets/Scripts/ObjectScripts/Helpers.meta
+++ b/Assets/Scripts/ObjectScripts/Helpers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: da8be5124903748cc9ebc8c1a949261f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ObjectScripts/Helpers/DayCycleRenderHelper.cs
+++ b/Assets/Scripts/ObjectScripts/Helpers/DayCycleRenderHelper.cs
@@ -1,12 +1,18 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class DayCycleRenderHelper : MonoBehaviour
 {
-    private Light m_sun;
+    [SerializeField]
+    private bool m_updateLighting = true;
 
-    /// The scene ambient color used for full daylight.  
+    [SerializeField]
+    private bool m_blendSkybox = true;
+
+    [SerializeField]
+    private bool m_updateFog = true;
+
+    private Light m_sun; 
     private static Color m_fullLight;
     private static Color m_fullDark;
     private static Color m_dawnDuskFog;
@@ -19,10 +25,12 @@ public class DayCycleRenderHelper : MonoBehaviour
         Initialize();
     }
 
-    public void Initialize()
+    /// <summary>
+    /// Initialize this component.
+    /// </summary>
+    private void Initialize()
     {
-        // find objects in scene.
-        // sun
+        // Find Sun object in scene.
         m_sun = GameObject.Find("Sun Directional Light")?.GetComponent<Light>();
 
         // Initialize lights
@@ -36,16 +44,37 @@ public class DayCycleRenderHelper : MonoBehaviour
             m_lightIntensity = m_sun.intensity;
         }
 
+        // Register event handler for time of day changes
         TimeManager.Ref.RegisterOnTimeOfDayChange(OnTimeOfDayChange);
     }
 
+    /// <summary>
+    /// Event handler for adjusting rendering effects based on
+    /// time of day.
+    /// </summary>
+    /// <param name="dayPhase">Time of day.</param>
     public void OnTimeOfDayChange(TimeManager.DayPhase dayPhase)
     {
-        UpdateDayCycleLighting(dayPhase);
-        UpdateSkyboxBlendFactor(dayPhase);
-        UpdateFog(dayPhase);
+        if (m_updateLighting)
+        {
+            UpdateDayCycleLighting(dayPhase);
+        }
+
+        if (m_blendSkybox)
+        {
+            UpdateSkyboxBlendFactor(dayPhase);
+        }
+
+        if (m_updateFog)
+        {
+            UpdateFog(dayPhase);
+        }
     }
 
+    /// <summary>
+    /// Update the scene lighting based on time of day changes.
+    /// </summary>
+    /// <param name="dayPhase">Time of day.</param>
     private void UpdateDayCycleLighting(TimeManager.DayPhase dayPhase)
     {
         switch (dayPhase)
@@ -77,6 +106,10 @@ public class DayCycleRenderHelper : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Blend the skybox from day to night based on the time of day changes.
+    /// </summary>
+    /// <param name="dayPhase">Time of day.</param>
     private void UpdateSkyboxBlendFactor(TimeManager.DayPhase dayPhase)
     {
         switch (dayPhase)
@@ -96,6 +129,10 @@ public class DayCycleRenderHelper : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Update fog based on time of day changes.
+    /// </summary>
+    /// <param name="dayPhase">Time of day.</param>
     private void UpdateFog(TimeManager.DayPhase dayPhase)
     {
         switch (dayPhase)
@@ -115,6 +152,14 @@ public class DayCycleRenderHelper : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Coroutine to fade scene lighting between the current phase
+    /// and the TimeManager.DayPhase provided.
+    /// </summary>
+    /// <param name="toPhase">TimeManager.DayPhase being transitioned to.</param>
+    /// <param name="fromColor">Lighting color being faded from.</param>
+    /// <param name="toColor">Lighting color being faded to.</param>
+    /// <returns>IEnumerator for coroutine.</returns>
     IEnumerator FadeLighting(TimeManager.DayPhase toPhase,
                              Color fromColor, Color toColor)
     {
@@ -144,6 +189,14 @@ public class DayCycleRenderHelper : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Coroutine to blend the skybox between day and night based on the
+    /// current day phase and the TimeManager.DayPhase provided.
+    /// </summary>
+    /// <param name="toPhase">TimeManager.DayPhase being transitioned to.</param>
+    /// <param name="fromValue">Blend value being transitioned from.</param>
+    /// <param name="toValue">Blend value being transitioned to.</param>
+    /// <returns>IEnumerator for coroutine.</returns>
     IEnumerator FadeSkyboxBlend(TimeManager.DayPhase toPhase, float fromValue, float toValue)
     {
         float timeRemaining = 1.0f;
@@ -158,6 +211,14 @@ public class DayCycleRenderHelper : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Coroutine to fade the fog values between the current day phase
+    /// and the TimeManager.DayPhase provided.
+    /// </summary>
+    /// <param name="toPhase">TimeManager.DayPhase being transitioned to.</param>
+    /// <param name="fromColor">Lighting color being faded from.</param>
+    /// <param name="toColor">Lighting color being faded to.</param>
+    /// <returns>IEnumerator for coroutine.</returns>
     IEnumerator FadeFog(TimeManager.DayPhase toPhase, Color fromColor, Color toColor)
     {
         float timeRemaining = 1.0f;

--- a/Assets/Scripts/ObjectScripts/Helpers/DayCycleRenderHelper.cs
+++ b/Assets/Scripts/ObjectScripts/Helpers/DayCycleRenderHelper.cs
@@ -1,0 +1,174 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DayCycleRenderHelper : MonoBehaviour
+{
+    private Light m_sun;
+
+    /// The scene ambient color used for full daylight.  
+    private static Color m_fullLight;
+    private static Color m_fullDark;
+    private static Color m_dawnDuskFog;
+    private static Color m_dayFog;
+    private static Color m_nightFog;
+    private float m_lightIntensity;
+
+    private void Start()
+    {
+        Initialize();
+    }
+
+    public void Initialize()
+    {
+        // find objects in scene.
+        // sun
+        m_sun = GameObject.Find("Sun Directional Light")?.GetComponent<Light>();
+
+        // Initialize lights
+        m_fullLight = new Color(253.0f / 255.0f, 248.0f / 255.0f, 223.0f / 255.0f);
+        m_fullDark = new Color(32.0f / 255.0f, 28.0f / 255.0f, 46.0f / 255.0f);
+        m_dawnDuskFog = new Color(133.0f / 255.0f, 124.0f / 255.0f, 102.0f / 255.0f);
+        m_dayFog = new Color(180.0f / 255.0f, 208.0f / 255.0f, 209.0f / 255.0f);
+        m_nightFog = new Color(12.0f / 255.0f, 15.0f / 255.0f, 91.0f / 255.0f);
+        if (m_sun != null)
+        {
+            m_lightIntensity = m_sun.intensity;
+        }
+
+        TimeManager.Ref.RegisterOnTimeOfDayChange(OnTimeOfDayChange);
+    }
+
+    public void OnTimeOfDayChange(TimeManager.DayPhase dayPhase)
+    {
+        UpdateDayCycleLighting(dayPhase);
+        UpdateSkyboxBlendFactor(dayPhase);
+        UpdateFog(dayPhase);
+    }
+
+    private void UpdateDayCycleLighting(TimeManager.DayPhase dayPhase)
+    {
+        switch (dayPhase)
+        {
+            case TimeManager.DayPhase.Dawn:
+                if (m_sun != null)
+                {
+                    m_sun.enabled = true;
+                }
+                StartCoroutine(FadeLighting(TimeManager.DayPhase.Day, m_fullDark, m_fullLight));
+                break;
+            case TimeManager.DayPhase.Day:
+                RenderSettings.ambientLight = m_fullLight;
+                if (m_sun != null)
+                {
+                    m_sun.intensity = m_lightIntensity;
+                }
+                break;
+            case TimeManager.DayPhase.Dusk:
+                StartCoroutine(FadeLighting(TimeManager.DayPhase.Night, m_fullLight, m_fullDark));
+                break;
+            case TimeManager.DayPhase.Night:
+                RenderSettings.ambientLight = m_fullDark;
+                if (m_sun != null)
+                {
+                    m_sun.enabled = false;
+                }
+                break;
+        }
+    }
+
+    private void UpdateSkyboxBlendFactor(TimeManager.DayPhase dayPhase)
+    {
+        switch (dayPhase)
+        {
+            case TimeManager.DayPhase.Dawn:
+                StartCoroutine(FadeSkyboxBlend(TimeManager.DayPhase.Day, 1.0f, 0.0f));
+                break;
+            case TimeManager.DayPhase.Day:
+                RenderSettings.skybox.SetFloat("_Blend", 0.0f);
+                break;
+            case TimeManager.DayPhase.Dusk:
+                StartCoroutine(FadeSkyboxBlend(TimeManager.DayPhase.Night, 0.0f, 1.0f));
+                break;
+            case TimeManager.DayPhase.Night:
+                RenderSettings.skybox.SetFloat("_Blend", 1.0f);
+                break;
+        }
+    }
+
+    private void UpdateFog(TimeManager.DayPhase dayPhase)
+    {
+        switch (dayPhase)
+        {
+            case TimeManager.DayPhase.Dawn:
+                StartCoroutine(FadeFog(TimeManager.DayPhase.Day, m_dawnDuskFog, m_dayFog));
+                break;
+            case TimeManager.DayPhase.Day:
+                StartCoroutine(FadeFog(TimeManager.DayPhase.Dusk, m_dayFog, m_dawnDuskFog));
+                break;
+            case TimeManager.DayPhase.Dusk:
+                StartCoroutine(FadeFog(TimeManager.DayPhase.Night, m_dawnDuskFog, m_nightFog));
+                break;
+            case TimeManager.DayPhase.Night:
+                StartCoroutine(FadeFog(TimeManager.DayPhase.Dusk, m_nightFog, m_dawnDuskFog));
+                break;
+        }
+    }
+
+    IEnumerator FadeLighting(TimeManager.DayPhase toPhase,
+                             Color fromColor, Color toColor)
+    {
+        float timeRemaining = 1.0f;
+        float currentPhaseLength = TimeManager.Ref.LengthOfCurrentPhase(); // TODO : if currentPhaseLength == 0!!
+
+        while (timeRemaining > 0.0f)
+        {
+            timeRemaining = TimeManager.Ref.TimeRemainingUntil(toPhase);
+            float interpolationTime = (currentPhaseLength - timeRemaining) / currentPhaseLength;
+
+            RenderSettings.ambientLight = Color.Lerp(fromColor, toColor, interpolationTime);
+
+            if(m_sun != null)
+            {
+                if (toPhase == TimeManager.DayPhase.Day)
+                {
+                    m_sun.intensity = m_lightIntensity * interpolationTime; // goes up 0->1
+                }
+                else if (toPhase == TimeManager.DayPhase.Night)
+                {
+                    m_sun.intensity = m_lightIntensity * (1 - interpolationTime); // goes down 1->0
+                }
+            }
+
+            yield return null; 
+        }
+    }
+
+    IEnumerator FadeSkyboxBlend(TimeManager.DayPhase toPhase, float fromValue, float toValue)
+    {
+        float timeRemaining = 1.0f;
+        float currentPhaseLength = TimeManager.Ref.LengthOfCurrentPhase(); // TODO : if currentPhaseLength == 0!!
+
+        while(timeRemaining > 0.0f)
+        {
+            timeRemaining = TimeManager.Ref.TimeRemainingUntil(toPhase);
+            float skyboxBlendFactor = (currentPhaseLength - timeRemaining) / currentPhaseLength;
+            RenderSettings.skybox.SetFloat("_Blend", skyboxBlendFactor);
+            yield return null;
+        }
+    }
+
+    IEnumerator FadeFog(TimeManager.DayPhase toPhase, Color fromColor, Color toColor)
+    {
+        float timeRemaining = 1.0f;
+        float currentPhaseLength = TimeManager.Ref.LengthOfCurrentPhase(); // TODO : if currentPhaseLength == 0!!
+
+        while (timeRemaining > 0.0f)
+        {
+            timeRemaining = TimeManager.Ref.TimeRemainingUntil(toPhase);
+            float interpolationTime = (currentPhaseLength - timeRemaining) / currentPhaseLength;
+            RenderSettings.fogColor = Color.Lerp(fromColor, toColor, interpolationTime);
+            yield return null;
+        }
+    }
+}

--- a/Assets/Scripts/ObjectScripts/Helpers/DayCycleRenderHelper.cs.meta
+++ b/Assets/Scripts/ObjectScripts/Helpers/DayCycleRenderHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14e2a2fa4d312467d9de7f29e63568e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Moved all rendering related helper functions from TimeManager into a component that can be attached to any object. It allows for blending the direction light used for the sun, Skybox blending, and fading between different colors of fog.

As part of these changes, the time keeping apparatus in TimeManager is also being refactored to not modify Time.timeScale directly to control game speed/time.