### PR TITLE
Feature/monster mode trigger

### DIFF
--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -120,6 +120,7 @@ public class GameManager : MonoBehaviour
         StartPath = (from PathPosition p in FindObjectsOfType<PathPosition>() orderby p.number ascending select p.transform.position).ToArray();
 
         TimeManager.Ref.RegisterOnTimeOfDayChange(OnTimeOfDayChange);
+        TimeManager.Ref.RegisterOnTriggerMonsterMode(OnTriggerMonsterMode);
     }
 
     public static int GetRandomizedGuestArival()
@@ -136,16 +137,16 @@ public class GameManager : MonoBehaviour
         switch(dayPhase)
         {
             case TimeManager.DayPhase.Dawn:
-                // TODO
+                SwapToDayMode();
                 break;
             case TimeManager.DayPhase.Day:
-                SwapToDayMode();
+                // TODO
                 break;
             case TimeManager.DayPhase.Dusk:
                 // TODO
                 break;
             case TimeManager.DayPhase.Night:
-                //SwapToNightMode();
+                // TODO
                 break;
         }
     }
@@ -158,13 +159,24 @@ public class GameManager : MonoBehaviour
         StartCoroutine(MonsterMode());
     }
 
+    /// <summary>
+    /// Coroutine to handle all Monster mode logic.
+    /// </summary>
+    /// <returns>IEnumerator</returns>
     IEnumerator MonsterMode()
     {
         // Enable Monster UI
         SwapToNightMode();
 
-        // Show Tarot Cards
+        // TODO : This is just for debugging until the Tarot
+        // scene is ready for integration. REMOVE IT AFTERWARDS!!
+        yield return new WaitForSeconds(15);
 
+        // TODO : Show Tarot Cards
+
+        // TODO : The remainder of monster mode logic
+
+        TimeManager.Ref.MonsterModeEnded();
         yield return null;
     }
 

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -145,9 +145,27 @@ public class GameManager : MonoBehaviour
                 // TODO
                 break;
             case TimeManager.DayPhase.Night:
-                SwapToNightMode();
+                //SwapToNightMode();
                 break;
         }
+    }
+
+    /// <summary>
+    /// Event handler for OnTriggerMonsterMode event.
+    /// </summary>
+    public void OnTriggerMonsterMode()
+    {
+        StartCoroutine(MonsterMode());
+    }
+
+    IEnumerator MonsterMode()
+    {
+        // Enable Monster UI
+        SwapToNightMode();
+
+        // Show Tarot Cards
+
+        yield return null;
     }
 
     /// <summary>
@@ -164,8 +182,6 @@ public class GameManager : MonoBehaviour
     /// </summary>
     private void SwapToNightMode()
     {
-        // TODO : Show Tarot cards
-
         // Update UI
         UIManager.Instance.SwitchUIMode(TimeManager.DayPhase.Night);
     }

--- a/Assets/Scripts/ObjectScripts/Helpers/DayCycleRenderHelper.cs
+++ b/Assets/Scripts/ObjectScripts/Helpers/DayCycleRenderHelper.cs
@@ -120,7 +120,6 @@ public class DayCycleRenderHelper : MonoBehaviour
     /// <param name="dayPhase">Time of day.</param>
     private void UpdateSkyboxBlendFactor(TimeManager.DayPhase dayPhase)
     {
-        //Debug.Log("Update skybox blend. From state : " + dayPhase.ToString());
         switch (dayPhase)
         {
             case TimeManager.DayPhase.Dawn:

--- a/Assets/Scripts/ObjectScripts/Helpers/DayCycleRenderHelper.cs
+++ b/Assets/Scripts/ObjectScripts/Helpers/DayCycleRenderHelper.cs
@@ -120,7 +120,7 @@ public class DayCycleRenderHelper : MonoBehaviour
     /// <param name="dayPhase">Time of day.</param>
     private void UpdateSkyboxBlendFactor(TimeManager.DayPhase dayPhase)
     {
-        Debug.Log("Update skybox blend. From state : " + dayPhase.ToString());
+        //Debug.Log("Update skybox blend. From state : " + dayPhase.ToString());
         switch (dayPhase)
         {
             case TimeManager.DayPhase.Dawn:

--- a/Assets/Scripts/ProtoTyping/CharacterSwaper.cs
+++ b/Assets/Scripts/ProtoTyping/CharacterSwaper.cs
@@ -98,8 +98,8 @@ public class CharacterSwaper : MonoBehaviour
         {
             setChar[i].SetCategoryAndLabel(setChar[i].name, charLabel[(int)j]);
             setChar[i].ResolveSpriteToSpriteRenderer();
-			if (GameManager.Debug)  Debug.Log(setChar[i].GetLabel().ToString());
-			Debug.Log(setChar[i].GetLabel().ToString());
+			//if (GameManager.Debug)  Debug.Log(setChar[i].GetLabel().ToString());
+			//Debug.Log(setChar[i].GetLabel().ToString());
 		}
     }
 
@@ -109,8 +109,8 @@ public class CharacterSwaper : MonoBehaviour
 		{
 			setChar[i].SetCategoryAndLabel(setChar[i].name, charLabel[j]);
 			setChar[i].ResolveSpriteToSpriteRenderer();
-			if (GameManager.Debug)  Debug.Log(setChar[i].GetLabel().ToString());
-			Debug.Log(setChar[i].GetLabel().ToString());
+			//if (GameManager.Debug)  Debug.Log(setChar[i].GetLabel().ToString());
+			//Debug.Log(setChar[i].GetLabel().ToString());
 		}
 
 	} 


### PR DESCRIPTION
Monster mode is now triggered by an event in TimeManager. The event is fired at midnight on the night of a full moon. There are 8 moon cycles and they change every night.

The UI only changes to monster mode, from build mode, whenever monster mode event fires. Previously it changed every day/night with the day cycle.