### PR TITLE
Fixed Unity deltaTime issue in TimeManager

### DIFF
--- a/Assets/Scripts/Managers/TimeManager.cs
+++ b/Assets/Scripts/Managers/TimeManager.cs
@@ -332,6 +332,12 @@ public class TimeManager : MonoBehaviour
     {
         float timeScale = 0.0f;
 
+        if(timeScalar == TimeScalar.UNITY)
+        {
+            scaledDeltaTime = Time.deltaTime;
+            return true;
+        }
+
         if(GetTimeScale(timeScalar, out timeScale))
         {
             scaledDeltaTime = Time.deltaTime * timeScale;


### PR DESCRIPTION
Fixed an issue where Unity Time.deltaTime was incorrectly scaled by the TimeManager API.